### PR TITLE
update jQuery link + clarify instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ You will be coding your solution in `index.html` and `js/selectors.js`. There ar
 
 ## Getting Everything Set Up
 
-First things first, we need to load several external resources to `index.html`:
+First things first, we need to load several resources to `index.html`:
 
 + jQuery: `<script type="text/javascript" src="js/jquery-2.1.1.min.js"></script>`
-
 + Our JS file: `<script src="js/selectors.js"></script>`
 
 Both of these script tags should go at the bottom the `body`. Order here matters. If we plan on using jQuery in `js/selectors.js`, the minified jQuery file needs to be linked first.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ You will be coding your solution in `index.html` and `js/selectors.js`. There ar
 
 First things first, we need to load several external resources to `index.html`:
 
-+ jQuery: `<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>`
++ jQuery: `<script type="text/javascript" src="js/jquery-2.1.1.min.js"></script>`
 
 + Our JS file: `<script src="js/selectors.js"></script>`
 
-Both of these script tags should go at the bottom the `body`. Order here matters. If we plan on using jQuery in `js/selectors.js`, that file needs to be linked first.
+Both of these script tags should go at the bottom the `body`. Order here matters. If we plan on using jQuery in `js/selectors.js`, the minified jQuery file needs to be linked first.
 
 
 ## Using Selectors
@@ -59,7 +59,7 @@ Just like in CSS, we use a `.` to denote a class. This code is selecting any HTM
 
 ### ID Selectors
 
-The first gif on the page is a baby doing ninja moves. An ID selector works in much the same way as a class selector, you just replace the `.` with a `#`:
+The first gif on the page is a baby doing ninja moves. An ID selector works in much the same way as a class selector; you just replace the `.` with a `#`:
 
 ```js
 $('#baby-ninja')
@@ -89,7 +89,7 @@ $('div img:first-child')
 
 ### Alt Tag Selector
 
-Let's say we want to select an image that has a specific alt text. The second image on our page (or the beatles) has the alt text `"the beatles making faces"`. We can use that text to find the image:
+Let's say we want to select an image that has a specific alt text. The second image on our page (The Beatles) has the alt text `"the beatles making faces"`. We can use that text to find the image:
 
 
 ```js
@@ -118,7 +118,7 @@ If you take a look at `js/selectors.js`, you'll notice we don't have a document 
 
 + Write a function `ninjaBabySelector` that does not accept any parameters. The function should use an ID selector to return the ninja baby image.
 
-+ Write a function `divSelector` that does not accept any parameters. The function should use a class selector to return the two divs on the page.
++ Write a function `divSelector` that does not accept any parameters. The function should use a class selector to return the two divs with the class `pics`.
 
 + Write a function `firstListItem` that does not accept any parameters. The function should use a first-child selector to return the first list item in the `ul` with the ID `pic-list`.
 
@@ -127,5 +127,3 @@ If you take a look at `js/selectors.js`, you'll notice we don't have a document 
 + [MDN jQuery Selectors](https://api.jquery.com/category/selectors/)
 
 <p data-visibility='hidden'>View <a href='https://learn.co/lessons/jquery-selectors-readme'>jQuery Selectors </a> on Learn.co and start learning to code for free.</p>
-
-<p class='util--hide'>View <a href='https://learn.co/lessons/jquery-selectors-readme'>jQuery Selectors Lab</a> on Learn.co and start learning to code for free.</p>


### PR DESCRIPTION
- remove CDN-linked jQuery 1.7 in favor of jQuery 2.1.1 that already comes packaged w/ the lesson files
- fix run-on
- clarify that the `divSelector` function is looking for `div.pics`; not plain old `div`
- remove dupe Learn link
